### PR TITLE
Make all tests async

### DIFF
--- a/priv/repo/migrations/20170527220454_create_space.exs
+++ b/priv/repo/migrations/20170527220454_create_space.exs
@@ -2,7 +2,7 @@ defmodule Level.Repo.Migrations.CreateSpace do
   use Ecto.Migration
 
   def up do
-    execute("CREATE EXTENSION citext")
+    execute("CREATE EXTENSION IF NOT EXISTS citext")
     execute("CREATE TYPE space_state AS ENUM ('ACTIVE','DISABLED')")
 
     create table(:spaces, primary_key: false) do

--- a/test/level/connections_test.exs
+++ b/test/level/connections_test.exs
@@ -1,5 +1,5 @@
 defmodule Level.ConnectionsTest do
-  use Level.DataCase
+  use Level.DataCase, async: true
 
   alias Level.Connections
 

--- a/test/level/groups_test.exs
+++ b/test/level/groups_test.exs
@@ -1,5 +1,5 @@
 defmodule Level.GroupsTest do
-  use Level.DataCase
+  use Level.DataCase, async: true
 
   alias Level.Groups
   alias Level.Groups.Group

--- a/test/level/pagination_test.exs
+++ b/test/level/pagination_test.exs
@@ -1,5 +1,5 @@
 defmodule Level.PaginationTest do
-  use Level.DataCase
+  use Level.DataCase, async: true
 
   alias Level.Pagination
   alias Level.Spaces.User

--- a/test/level/spaces/invitation_repo_test.exs
+++ b/test/level/spaces/invitation_repo_test.exs
@@ -1,5 +1,5 @@
 defmodule Level.Spaces.InvitationRepoTest do
-  use Level.DataCase
+  use Level.DataCase, async: true
   use Bamboo.Test
 
   alias Level.Spaces

--- a/test/level/spaces/registration_repo_test.exs
+++ b/test/level/spaces/registration_repo_test.exs
@@ -1,5 +1,5 @@
 defmodule Level.Spaces.RegistrationRepoTest do
-  use Level.DataCase
+  use Level.DataCase, async: true
 
   alias Level.Spaces.Registration
 

--- a/test/level/spaces_test.exs
+++ b/test/level/spaces_test.exs
@@ -1,5 +1,5 @@
 defmodule Level.SpacesTest do
-  use Level.DataCase
+  use Level.DataCase, async: true
   use Bamboo.Test
 
   alias Level.Spaces

--- a/test/level_web/channels/user_socket_test.exs
+++ b/test/level_web/channels/user_socket_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.UserSocketTest do
-  use LevelWeb.ChannelCase
+  use LevelWeb.ChannelCase, async: true
 
   describe "connect/2" do
     setup do

--- a/test/level_web/controllers/accept_invitation_controller_test.exs
+++ b/test/level_web/controllers/accept_invitation_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.AcceptInvitationControllerTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
 
   alias Level.Spaces
 

--- a/test/level_web/controllers/api/signup_errors_controller_test.exs
+++ b/test/level_web/controllers/api/signup_errors_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.API.SignupErrorsControllerTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
 
   describe "POST /api/signup/errors" do
     setup %{conn: conn} do

--- a/test/level_web/controllers/api/space_controller_test.exs
+++ b/test/level_web/controllers/api/space_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.API.SpaceControllerTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
 
   alias LevelWeb.API.SpaceView
 

--- a/test/level_web/controllers/api/user_token_controller_test.exs
+++ b/test/level_web/controllers/api/user_token_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.API.UserTokenControllerTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
 
   describe "POST /api/tokens" do
     setup %{conn: conn} do

--- a/test/level_web/controllers/invitation_controller_test.exs
+++ b/test/level_web/controllers/invitation_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.InvitationControllerTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
 
   # alias Level.Spaces.Invitation
   alias Level.Spaces

--- a/test/level_web/controllers/page_controller_test.exs
+++ b/test/level_web/controllers/page_controller_test.exs
@@ -1,3 +1,0 @@
-defmodule LevelWeb.PageControllerTest do
-  use LevelWeb.ConnCase
-end

--- a/test/level_web/controllers/session_controller_test.exs
+++ b/test/level_web/controllers/session_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.SessionControllerTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
 
   describe "GET /login" do
     test "includes the correct heading", %{conn: conn} do

--- a/test/level_web/controllers/space_controller_test.exs
+++ b/test/level_web/controllers/space_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.SpaceControllerTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
 
   describe "GET /" do
     setup %{conn: conn} do

--- a/test/level_web/controllers/space_search_controller_test.exs
+++ b/test/level_web/controllers/space_search_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.SpaceSearchControllerTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
 
   describe "GET /spaces/search" do
     test "includes the correct heading", %{conn: conn} do

--- a/test/level_web/email_test.exs
+++ b/test/level_web/email_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.EmailTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use Bamboo.Test
 
   describe "invitation_email/1" do

--- a/test/level_web/graphql/mutations/create_group_test.exs
+++ b/test/level_web/graphql/mutations/create_group_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.GraphQL.CreateGroupTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
   import LevelWeb.GraphQL.TestHelpers
 
   alias Level.Groups

--- a/test/level_web/graphql/mutations/invite_user_test.exs
+++ b/test/level_web/graphql/mutations/invite_user_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.GraphQL.InviteUserTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
   import LevelWeb.GraphQL.TestHelpers
 
   setup %{conn: conn} do

--- a/test/level_web/graphql/mutations/revoke_invitation_test.exs
+++ b/test/level_web/graphql/mutations/revoke_invitation_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.GraphQL.RevokeInvitationTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
   import LevelWeb.GraphQL.TestHelpers
 
   alias Level.Spaces

--- a/test/level_web/graphql/queries/groups_test.exs
+++ b/test/level_web/graphql/queries/groups_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.GraphQL.GroupsTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
   import LevelWeb.GraphQL.TestHelpers
 
   alias Level.Groups

--- a/test/level_web/graphql/queries/invitations_test.exs
+++ b/test/level_web/graphql/queries/invitations_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.GraphQL.InvitationsTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
   import LevelWeb.GraphQL.TestHelpers
 
   setup %{conn: conn} do

--- a/test/level_web/graphql/queries/space_test.exs
+++ b/test/level_web/graphql/queries/space_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.GraphQL.SpaceTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
   import LevelWeb.GraphQL.TestHelpers
 
   setup %{conn: conn} do

--- a/test/level_web/graphql/queries/viewer_test.exs
+++ b/test/level_web/graphql/queries/viewer_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.GraphQL.ViewerTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
   import LevelWeb.GraphQL.TestHelpers
 
   setup %{conn: conn} do

--- a/test/level_web/plugs/auth_test.exs
+++ b/test/level_web/plugs/auth_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.AuthTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
   alias LevelWeb.Auth
 
   setup %{conn: conn} do

--- a/test/level_web/plugs/subdomain_test.exs
+++ b/test/level_web/plugs/subdomain_test.exs
@@ -1,5 +1,5 @@
 defmodule LevelWeb.SubdomainTest do
-  use LevelWeb.ConnCase
+  use LevelWeb.ConnCase, async: true
   alias LevelWeb.Subdomain
 
   describe "validate_host/2" do

--- a/test/level_web/views/layout_view_test.exs
+++ b/test/level_web/views/layout_view_test.exs
@@ -1,3 +1,0 @@
-defmodule LevelWeb.LayoutViewTest do
-  use LevelWeb.ConnCase, async: true
-end

--- a/test/level_web/views/page_view_test.exs
+++ b/test/level_web/views/page_view_test.exs
@@ -1,3 +1,0 @@
-defmodule LevelWeb.PageViewTest do
-  use LevelWeb.ConnCase, async: true
-end

--- a/test/level_web/views/space_view_test.exs
+++ b/test/level_web/views/space_view_test.exs
@@ -1,3 +1,0 @@
-defmodule LevelWeb.SpaceViewTest do
-  use LevelWeb.ConnCase, async: true
-end


### PR DESCRIPTION
There were a lot of tests that could have been running async that
weren't tagged as such, so I went ahead and added that tag. On my
machine this decreased test run time from ~4.4 seconds to ~3.2 seconds.

I also deleted a couple test files that didn't have any tests in them.

I know, not a huge real-world difference now, but later on when this
test suite gets much bigger, that 25% will probably make a more
significant difference!

Also, thanks for the handy-dandy setup script! Always very nice to have
that. I did make a change to a migration to make that setup a little less
likely to throw errors for folks (as happened to me when I went in and
manually added the `citext` extension because my `postgres` user
wasn't a superuser).