### PR TITLE
Add check for formatting to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,9 @@ jobs:
       - run:
           name: "Run Elixir linting"
           command: mix credo
+      - run:
+          name: "Run Elixir formatter check"
+          command: mix format --check-formatted
 
   build_and_test_elm:
     docker:

--- a/test/level_web/graphql/queries/invitations_test.exs
+++ b/test/level_web/graphql/queries/invitations_test.exs
@@ -46,7 +46,8 @@ defmodule LevelWeb.GraphQL.InvitationsTest do
                            "id" => to_string(invitation.id),
                            "email" => invitation.email,
                            "insertedAt" =>
-                             invitation.inserted_at |> Timex.to_datetime()
+                             invitation.inserted_at
+                             |> Timex.to_datetime()
                              |> DateTime.to_iso8601()
                          }
                        }


### PR DESCRIPTION
Keeping things formatted is _way_ easier if you do it starting at the
beginning of a project, and hooking it into CI I've found to be very
helpful. `mix format --check-formatted` will use your `.formatter.exs`
settings to determine if any changes would be made by running `mix
format`, and if any changes would be made, exits with a `1` and fails
the build.

The file that I formatted here was failing that check, so I formatted it
😉 