### PR TITLE
Speed up CI runs by caching PLTs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,12 @@
 version: 2
 jobs:
-  build_elixir:
+  build_and_test_elixir:
     docker:
       - image: circleci/elixir:1.6.4
+      - image: circleci/postgres:9.6.2
+
+    environment:
+      COVERALLS_REPO_TOKEN: WQJAD2rl0QMcK0OukyWM49Aq1gXqQEJXY
 
     working_directory: /home/circleci/repo
     steps:
@@ -22,36 +26,6 @@ jobs:
       - run:
           name: "Compile Elixir source"
           command: mix compile
-      - save_cache:
-          key: elixir-build-v2-{{ checksum "mix.exs" }}
-          paths:
-            - '_build'
-            - 'deps'
-
-  test_elixir:
-    docker:
-      - image: circleci/elixir:1.6.4
-      - image: circleci/postgres:9.6.2
-
-    environment:
-      COVERALLS_REPO_TOKEN: WQJAD2rl0QMcK0OukyWM49Aq1gXqQEJXY
-
-    working_directory: /home/circleci/repo
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - elixir-build-v2-{{ checksum "mix.exs" }}
-      - restore_cache:
-          keys:
-            - v1-plt-cache-{{ checksum "mix.lock" }}
-            - v1-plt-cache
-      - run:
-          name: "Install Hex"
-          command: mix local.hex --force
-      - run:
-          name: "Install Rebar"
-          command: mix local.rebar --force
       - run:
           name: "Create the test database"
           command: mix ecto.create
@@ -68,9 +42,10 @@ jobs:
           name: "Run dialyzer"
           command: mix dialyzer
       - save_cache:
-          key: v1-plt-cache-{{ checksum "mix.lock" }}
+          key: elixir-build-v2-{{ checksum "mix.lock" }}
           paths:
             - '_build'
+            - 'deps'
             - '~/.mix'
 
   build_and_test_elm:
@@ -88,7 +63,7 @@ jobs:
             - elm-stuff-v5-{{ checksum "assets/elm/elm-package.json" }}-{{ checksum "assets/elm/tests/elm-package.json" }}
       - restore_cache:
           keys:
-            - elixir-build-v2-{{ checksum "mix.exs" }}
+            - elixir-build-v2-{{ checksum "mix.lock" }}
       - run:
           name: "Install yarn packages"
           command: cd assets && yarn install
@@ -130,10 +105,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build_elixir
-      - test_elixir:
-          requires:
-            - build_elixir
+      - build_and_test_elixir
       - build_and_test_elm:
           requires:
-            - build_elixir
+            - build_and_test_elixir

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,10 @@ jobs:
       - restore_cache:
           keys:
             - elixir-build-v2-{{ checksum "mix.exs" }}
+      - restore_cache:
+          keys:
+            - v1-plt-cache-{{ checksum "mix.lock" }}
+            - v1-plt-cache
       - run:
           name: "Install Hex"
           command: mix local.hex --force
@@ -62,7 +66,12 @@ jobs:
           command: mix format --check-formatted
       - run:
           name: "Run dialyzer"
-          command: mix dialyzer --plt
+          command: mix dialyzer
+      - save_cache:
+          key: v1-plt-cache-{{ checksum "mix.lock" }}
+          paths:
+            - '_build'
+            - '~/.mix'
 
   build_and_test_elm:
     docker:


### PR DESCRIPTION
The main thing that takes a ton of time for Dialyzer is building the
PLT (persistent lookup table). Luckily, CircleCI 2.0 gives us some
caching options to speed that up! This should make things run
significantly faster.