### PR TITLE
Close webpack watcher when shutting down server

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -17,7 +17,7 @@ config :level, LevelWeb.Endpoint,
       "node_modules/webpack/bin/webpack.js",
       "--mode",
       "development",
-      "--watch",
+      "--watch-stdin",
       cd: Path.expand("../assets", __DIR__)
     ]
   ]


### PR DESCRIPTION
My CPU was spiking to 100% and noticed that webpack wasn't closing old watchers on phoenix server shutdown.

webpack/webpack#1308