### PR TITLE
Remove subdomain references in url helpers

### DIFF
--- a/lib/level_web/url_helpers.ex
+++ b/lib/level_web/url_helpers.ex
@@ -4,38 +4,26 @@ defmodule LevelWeb.UrlHelpers do
   """
 
   alias LevelWeb.Router.Helpers
-  alias LevelWeb.Endpoint
 
   def signup_url(conn) do
     URI.to_string(%{
       build_uri_from_conn(conn)
-      | host: "launch.#{default_host()}",
-        path: Helpers.space_path(conn, :new)
+      | path: Helpers.space_path(conn, :new)
     })
   end
 
   def space_login_url(conn, space) do
     URI.to_string(%{
       build_uri_from_conn(conn)
-      | host: "#{space.slug}.#{default_host()}",
-        path: Helpers.session_path(conn, :new)
+      | path: Helpers.session_path(conn, :new)
     })
   end
 
   def threads_url(conn, space) do
     URI.to_string(%{
       build_uri_from_conn(conn)
-      | host: "#{space.slug}.#{default_host()}",
-        path: Helpers.cockpit_path(conn, :index)
+      | path: Helpers.cockpit_path(conn, :index)
     })
-  end
-
-  def default_host do
-    Keyword.get(default_url_config(), :host)
-  end
-
-  defp default_url_config do
-    Application.get_env(:level, Endpoint)[:url]
   end
 
   defp build_uri_from_conn(conn) do

--- a/lib/level_web/views/space_view.ex
+++ b/lib/level_web/views/space_view.ex
@@ -2,8 +2,4 @@ defmodule LevelWeb.SpaceView do
   @moduledoc false
 
   use LevelWeb, :view
-
-  def space_host(space) do
-    "#{space.slug}.#{default_host()}"
-  end
 end


### PR DESCRIPTION
I'm assuming these can also either be removed or partitioned using the `space.slug`

```elixir
def space_login_url(conn, space) do
     URI.to_string(%{
       build_uri_from_conn(conn)
      | path: Helpers.session_path(conn, :new)
     })
   end
 
   def threads_url(conn, space) do
     URI.to_string(%{
       build_uri_from_conn(conn)
      | path: Helpers.cockpit_path(conn, :index)
     })
   end
```
