### PR TITLE
Fix redirection when missing auth on graphiql

### DIFF
--- a/lib/level_web/router.ex
+++ b/lib/level_web/router.ex
@@ -51,7 +51,11 @@ defmodule LevelWeb.Router do
   end
 
   scope "/" do
-    pipe_through [:anonymous_browser, :fetch_current_user_by_session]
+    pipe_through [
+      :anonymous_browser,
+      :fetch_current_user_by_session,
+      :redirect_unless_signed_in
+    ]
 
     forward "/graphiql", Absinthe.Plug.GraphiQL,
       schema: LevelWeb.Schema,

--- a/test/level_web/graphql/graphiql_test.exs
+++ b/test/level_web/graphql/graphiql_test.exs
@@ -1,7 +1,7 @@
-defmodule LevelWeb.GraphQL.GraphiQL do
+defmodule LevelWeb.GraphQL.GraphiQLTest do
   use LevelWeb.ConnCase, async: true
 
-  describe "/grapiql authentication rules" do
+  describe "/graphiql authentication rules" do
     setup %{conn: conn} do
       conn =
         conn

--- a/test/level_web/graphql/graphiql_test.exs
+++ b/test/level_web/graphql/graphiql_test.exs
@@ -1,29 +1,32 @@
 defmodule LevelWeb.GraphQL.GraphiQL do
- use LevelWeb.ConnCase, async: true
+  use LevelWeb.ConnCase, async: true
 
- describe "/grapiql authentication rules" do
+  describe "/grapiql authentication rules" do
+    setup %{conn: conn} do
+      conn =
+        conn
+        |> bypass_through(LevelWeb.Router, :anonymous_browser)
+        |> get("/graphiql")
 
-  setup %{conn: conn} do
-    conn =
-      conn
-      |> bypass_through(LevelWeb.Router, :anonymous_browser)
-      |> get("/graphiql")
+      {:ok, %{conn: conn}}
+    end
 
-    {:ok, %{conn: conn}}
+    test "unauthenticated user should not be able to access /graphiql", %{conn: conn} do
+      conn = get(conn, "/graphiql")
+      assert redirected_to(conn, 302) =~ "/login"
+    end
+
+    test "authenticated users can access /graphiql", %{conn: conn} do
+      {:ok, user} = create_user()
+
+      conn =
+        conn
+        |> sign_in(user)
+        # we want the page not the api
+        |> put_req_header("accept", "text/html")
+        |> get("/graphiql")
+
+      assert html_response(conn, 200)
+    end
   end
-  test "unauthenticated user should not be able to access /graphiql", %{conn: conn} do
-    conn = get(conn, "/graphiql")
-    assert redirected_to(conn, 302) =~ "/login"
-  end
-
-  test "authenticated users can access /graphiql", %{conn: conn} do
-    {:ok, user} = create_user()
-    conn =
-      conn
-      |> sign_in(user)
-      |> put_req_header("accept", "text/html") # we want the page not the api
-      |> get("/graphiql")
-    assert html_response(conn, 200)
-  end
- end
 end

--- a/test/level_web/graphql/graphiql_test.exs
+++ b/test/level_web/graphql/graphiql_test.exs
@@ -1,0 +1,29 @@
+defmodule LevelWeb.GraphQL.GraphiQL do
+ use LevelWeb.ConnCase, async: true
+
+ describe "/grapiql authentication rules" do
+
+  setup %{conn: conn} do
+    conn =
+      conn
+      |> bypass_through(LevelWeb.Router, :anonymous_browser)
+      |> get("/graphiql")
+
+    {:ok, %{conn: conn}}
+  end
+  test "unauthenticated user should not be able to access /graphiql", %{conn: conn} do
+    conn = get(conn, "/graphiql")
+    assert redirected_to(conn, 302) =~ "/login"
+  end
+
+  test "authenticated users can access /graphiql", %{conn: conn} do
+    {:ok, user} = create_user()
+    conn =
+      conn
+      |> sign_in(user)
+      |> put_req_header("accept", "text/html") # we want the page not the api
+      |> get("/graphiql")
+    assert html_response(conn, 200)
+  end
+ end
+end


### PR DESCRIPTION
Here we add the already present `redirect_unless_signed_in` plug
to the pieline that GraphiQL is run
This asserts that the current user is set and if not itt redirects to 
the login page, not even going to any controller

Fix #83