### PR TITLE
Move notification HTTP calls into a separate worker

### DIFF
--- a/lib/level/web_push.ex
+++ b/lib/level/web_push.ex
@@ -12,8 +12,9 @@ defmodule Level.WebPush do
   alias Level.WebPush.Payload
   alias Level.WebPush.Schema
   alias Level.WebPush.Subscription
-  alias Level.WebPush.User
+  alias Level.WebPush.SubscriptionSupervisor
   alias Level.WebPush.UserSupervisor
+  alias Level.WebPush.UserWorker
 
   @doc """
   Starts the process supervisor.
@@ -25,7 +26,8 @@ defmodule Level.WebPush do
   @impl true
   def init(_arg) do
     children = [
-      UserSupervisor
+      UserSupervisor,
+      SubscriptionSupervisor
     ]
 
     Supervisor.init(children, strategy: :one_for_one)
@@ -118,21 +120,21 @@ defmodule Level.WebPush do
   @spec send_web_push(String.t(), Payload.t()) :: :ok | :ignore | {:error, any()}
   def send_web_push(user_id, %Payload{} = payload) do
     user_id
-    |> UserSupervisor.start_user()
-    |> handle_start_user(user_id, payload)
+    |> UserSupervisor.start_worker()
+    |> handle_start_worker(user_id, payload)
   end
 
-  defp handle_start_user({:ok, _pid}, user_id, payload) do
-    User.send_web_push(user_id, payload)
+  defp handle_start_worker({:ok, _pid}, user_id, payload) do
+    UserWorker.send_web_push(user_id, payload)
   end
 
-  defp handle_start_user({:ok, _pid, _info}, user_id, payload) do
-    User.send_web_push(user_id, payload)
+  defp handle_start_worker({:ok, _pid, _info}, user_id, payload) do
+    UserWorker.send_web_push(user_id, payload)
   end
 
-  defp handle_start_user({:error, {:already_started, _pid}}, user_id, payload) do
-    User.send_web_push(user_id, payload)
+  defp handle_start_worker({:error, {:already_started, _pid}}, user_id, payload) do
+    UserWorker.send_web_push(user_id, payload)
   end
 
-  defp handle_start_user(err, _, _), do: err
+  defp handle_start_worker(err, _, _), do: err
 end

--- a/lib/level/web_push/subscription_supervisor.ex
+++ b/lib/level/web_push/subscription_supervisor.ex
@@ -1,11 +1,11 @@
-defmodule Level.WebPush.UserSupervisor do
+defmodule Level.WebPush.SubscriptionSupervisor do
   @moduledoc """
-  The supervisor for user processes.
+  The supervisor for subscription processes.
   """
 
   use DynamicSupervisor
 
-  alias Level.WebPush.UserWorker
+  alias Level.WebPush.SubscriptionWorker
 
   # Client
 
@@ -13,8 +13,8 @@ defmodule Level.WebPush.UserSupervisor do
     DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
 
-  def start_worker(user_id) do
-    spec = {UserWorker, user_id}
+  def start_worker(id, subscription) do
+    spec = {SubscriptionWorker, [id, subscription]}
     DynamicSupervisor.start_child(__MODULE__, spec)
   end
 

--- a/lib/level/web_push/subscription_worker.ex
+++ b/lib/level/web_push/subscription_worker.ex
@@ -1,0 +1,56 @@
+defmodule Level.WebPush.SubscriptionWorker do
+  @moduledoc """
+  A worker process for sending notifications to a subscription.
+  """
+
+  use GenServer
+
+  alias Level.WebPush.Payload
+  alias Level.WebPush.Subscription
+
+  defstruct [:subscription]
+
+  @type t :: %__MODULE__{
+          subscription: Subscription.t()
+        }
+
+  # Client
+
+  def start_link([id, subscription]) do
+    GenServer.start_link(__MODULE__, subscription, name: via_tuple(id))
+  end
+
+  def registry_key(id) do
+    {:web_push_subscription, id}
+  end
+
+  defp via_tuple(id) do
+    {:via, Registry, {Level.Registry, registry_key(id)}}
+  end
+
+  def send_web_push(id, %Payload{} = payload) do
+    GenServer.cast(via_tuple(id), {:send_web_push, payload})
+  end
+
+  # Server
+
+  @impl true
+  def init(subscription) do
+    {:ok, %__MODULE__{subscription: subscription}}
+  end
+
+  @impl true
+  def handle_cast({:send_web_push, payload}, state) do
+    payload
+    |> Payload.serialize()
+    |> adapter().send_web_push(state.subscription)
+
+    {:noreply, state}
+  end
+
+  # Internal
+
+  defp adapter do
+    Application.get_env(:level, Level.WebPush)[:adapter]
+  end
+end


### PR DESCRIPTION
- [ ] Implement retry logic when request fails
- [ ] Implement removal of the subscription when 404 or 410 is returned
- [ ] Handle 429 response (rate limiting)
- [ ] Log other failures

See https://developers.google.com/web/fundamentals/push-notifications/web-push-protocol